### PR TITLE
Feature er/tunetwins external

### DIFF
--- a/frontend/src/components/PlayButton/PlayCard.js
+++ b/frontend/src/components/PlayButton/PlayCard.js
@@ -1,8 +1,25 @@
 import classNames from "classnames";
 
 import Histogram from "../Histogram/Histogram";
-
+import { MEDIA_ROOT } from "../../config";
 const PlayCard = ({ onClick, registerUserClicks, playing, section }) => {
+
+    // preload the section (temporary solution for ICMPC)
+    const audioBuffer = document.createElement("audio");
+    audioBuffer.id = `buffer-${section.id}`;    
+    audioBuffer.src = MEDIA_ROOT + section.url;
+    audioBuffer.crossorigin = "use-credentials";
+    audioBuffer.disableRemotePlayback = true;
+    audioBuffer.style.display = "none";
+
+    // Required for Firefox to trigger canplaythrough event
+    audioBuffer.preload = "auto";
+
+    // Required for Safari/iOS
+    audioBuffer.load();
+
+    // Add it to the page
+    document.body.appendChild(audioBuffer);
     
     return (
         <div className={classNames("aha__play-card", {turned: section.turned}, {noevents: section.noevents}, {disabled: section.inactive}, { memory: section.memory }, { lucky: section.lucky }, { nomatch: section.nomatch })} onClick={event => {
@@ -21,7 +38,7 @@ const PlayCard = ({ onClick, registerUserClicks, playing, section }) => {
                     :
                     <div className={classNames("back", {seen: section.seen})}>
                     </div>
-                }
+            }            
         </div>
     );
 };

--- a/frontend/src/components/PlayButton/PlayCard.js
+++ b/frontend/src/components/PlayButton/PlayCard.js
@@ -1,25 +1,36 @@
+import React, {useEffect, useState} from "react";
 import classNames from "classnames";
 
 import Histogram from "../Histogram/Histogram";
 import { MEDIA_ROOT } from "../../config";
 const PlayCard = ({ onClick, registerUserClicks, playing, section }) => {
+    const [firstRender, setFirstRender] = useState(false);
 
-    // preload the section (temporary solution for ICMPC)
-    const audioBuffer = document.createElement("audio");
-    audioBuffer.id = `buffer-${section.id}`;    
-    audioBuffer.src = MEDIA_ROOT + section.url;
-    audioBuffer.crossorigin = "use-credentials";
-    audioBuffer.disableRemotePlayback = true;
-    audioBuffer.style.display = "none";
+    useEffect(() => {
+        if (!firstRender) {
+          createBuffer();
+          setFirstRender(true);
+        }
+    }, [firstRender])
+    
+    const createBuffer = () => {
+        // preload the section (temporary solution for ICMPC)
+        const audioBuffer = document.createElement("audio");
+        audioBuffer.id = `buffer-${section.id}`;    
+        audioBuffer.src = MEDIA_ROOT + section.url;
+        audioBuffer.crossorigin = "use-credentials";
+        audioBuffer.disableRemotePlayback = true;
+        audioBuffer.style.display = "none";
 
-    // Required for Firefox to trigger canplaythrough event
-    audioBuffer.preload = "auto";
+        // Required for Firefox to trigger canplaythrough event
+        audioBuffer.preload = "auto";
 
-    // Required for Safari/iOS
-    audioBuffer.load();
+        // Required for Safari/iOS
+        audioBuffer.load();
 
-    // Add it to the page
-    document.body.appendChild(audioBuffer);
+        // Add it to the page
+        document.body.appendChild(audioBuffer);
+    }
     
     return (
         <div className={classNames("aha__play-card", {turned: section.turned}, {noevents: section.noevents}, {disabled: section.inactive}, { memory: section.memory }, { lucky: section.lucky }, { nomatch: section.nomatch })} onClick={event => {

--- a/frontend/src/components/Playback/Playback.js
+++ b/frontend/src/components/Playback/Playback.js
@@ -115,9 +115,7 @@ const Playback = ({
 
     // Play section with given index
     const playSection = useCallback(
-        (index = 0) => {
-            // set corssorigin for web-audio
-            document.getElementById('audio-player').setAttribute('crossOrigin', 'use-credentials');
+        (index = 0) => {            
             // Load different audio
             if (index !== lastPlayerIndex.current) {
                 audio.loadUntilAvailable(


### PR DESCRIPTION
This PR is a temporary solution to solve the latency with tunetwins when playing from Japan.
For every playcard an `<audio>` tag is created, with the same attributes as the main `<audio>` tag, but with an `id` labeled `buffer-<section.id>`.
These audio elements are never used, but preload the audio files in cache before the games begins. 