### PR TITLE
Feature er/tunetwins visual tweaks

### DIFF
--- a/frontend/src/components/Playback/MatchingPairs.js
+++ b/frontend/src/components/Playback/MatchingPairs.js
@@ -10,8 +10,7 @@ const MatchingPairs = ({
     finishedPlaying,
     stopAudioAfter,
     submitResult,
-}) => {
-    const finishDelay = 1500;
+}) => {    
     const xPosition = useRef(-1);
     const yPosition = useRef(-1);
     const score = useRef(undefined);
@@ -70,7 +69,7 @@ const MatchingPairs = ({
                     setTimeout(() => {
                         turnedCards[0].nomatch = false;
                         turnedCards[1].nomatch = false;                        
-                      }, finishDelay);
+                      }, 700);
                     break;  
             }   
 

--- a/frontend/src/components/Playback/MatchingPairs.scss
+++ b/frontend/src/components/Playback/MatchingPairs.scss
@@ -13,8 +13,10 @@
 }
 
 .aha__matching-pairs {
-    margin: 0px auto;
-    max-width: 100%;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 0px auto;    
 }
 
 @media (min-aspect-ratio: 1/1)  {
@@ -35,7 +37,7 @@
 
 .playing-board {
     display: inline-grid;
-    max-width: 100%;
+    max-width: 100%;    
 }
 
 .matching-pairs__feedback, .matching-pairs__score {


### PR DESCRIPTION
This PR ensures the playing board is always centered on all devices.
It also fixes the nomatch animation bug where only one card would shake. This appeared when you clicked through the cards real fast, so that the nomatch class was still on a card from a previous turn and the animation didn't get triggered. 